### PR TITLE
fix bug in get-api-articles-article_id-comments endpoint

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -248,7 +248,7 @@ describe("/api/articles/:article-id/comments", () => {
       .expect(200)
       .then(({ body }) => {
         expect(Array.isArray(body)).toBe(true);
-        expect(body.length).toBeGreaterThan(0);
+        expect(body.length).toBe(11);
         body.forEach((comment) => {
           expect(typeof comment.comment_id).toBe("number");
           expect(typeof comment.votes).toBe("number");
@@ -256,15 +256,26 @@ describe("/api/articles/:article-id/comments", () => {
           expect(typeof comment.author).toBe("string");
           expect(typeof comment.body).toBe("string");
           expect(typeof comment.article_id).toBe("number");
+          expect(body).toBeSortedBy("created_at", { descending: true });
         });
       });
   });
-  test("GET:404 - responds with message: Not Found when a valid, non-existing article_id is given", () => {
+  test("GET:200 - responds with an empty array when given an existing article_id that has no comments", () => {
+    return request(app)
+      .get("/api/articles/4/comments")
+      .expect(200)
+      .then(({ body }) => {
+        expect(Array.isArray(body)).toBe(true);
+        expect(body.length).toBe(0);
+        expect(body).toEqual([]);
+      });
+  });
+  test("GET:404 - responds with message: Article Not Found when a valid, non-existing article_id is given", () => {
     return request(app)
       .get("/api/articles/9999/comments")
       .expect(404)
       .then(({ body }) => {
-        expect(body.message).toBe("Not Found");
+        expect(body.message).toBe("Article Not Found");
       });
   });
   test("GET:400 - responds with message: Bad Request when a non-valid article_id is given", () => {

--- a/controllers/article-controllers.js
+++ b/controllers/article-controllers.js
@@ -37,9 +37,12 @@ exports.getArticleById = (req, res, next) => {
 
 exports.getCommentsByArticleId = (req, res, next) => {
   const { article_id } = req.params;
-  fetchCommentsByArticleId(article_id)
+  const fetchQuery = fetchCommentsByArticleId(article_id);
+  const articleExistsQuery = checkArticleIdExists(article_id);
+
+  Promise.all([fetchQuery, articleExistsQuery])
     .then((rows) => {
-      res.status(200).send(rows);
+      res.status(200).send(rows[0]);
     })
     .catch((err) => {
       next(err);

--- a/models/article-models.js
+++ b/models/article-models.js
@@ -48,9 +48,6 @@ exports.fetchCommentsByArticleId = (articleId) => {
       [articleId]
     )
     .then(({ rows }) => {
-      if (rows.length === 0) {
-        return Promise.reject({ message: "Not Found" });
-      }
       return rows;
     });
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "env": "^0.0.2",
         "express": "^4.18.2",
         "fs.promises": "^0.1.2",
-        "pg": "^8.11.3"
+        "pg": "^8.11.3",
+        "pg-format": "^1.0.4"
       },
       "devDependencies": {
         "husky": "^8.0.2",


### PR DESCRIPTION
Adds new sort test to endpoint get-api-articles-article_id-comments.
Also fixes bug so now an existing article_id with no comments will return an empty array.